### PR TITLE
16 usecase ontkoppel bestekkoppelingen

### DIFF
--- a/API/EMInfraDomain.py
+++ b/API/EMInfraDomain.py
@@ -242,10 +242,10 @@ class QueryDTO(BaseDataclass):
 @dataclass
 class BestekRef(BaseDataclass):
     uuid: str
-    awvId: str
     type: str
     actief: bool
     links: [Link]
+    awvId: str | None = None
     eDeltaDossiernummer: str | None = None
     eDeltaBesteknummer: str | None = None
     aannemerNaam: str | None = None

--- a/API/EMInfraDomain.py
+++ b/API/EMInfraDomain.py
@@ -243,13 +243,13 @@ class QueryDTO(BaseDataclass):
 class BestekRef(BaseDataclass):
     uuid: str
     awvId: str
-    eDeltaDossiernummer: str
-    eDeltaBesteknummer: str
     type: str
-    aannemerNaam: str
-    aannemerReferentie: str
     actief: bool
     links: [Link]
+    eDeltaDossiernummer: str | None
+    eDeltaBesteknummer: str | None
+    aannemerNaam: str | None
+    aannemerReferentie: str | None
     nummer: str | None = None
     lot: str | None = None
 

--- a/API/EMInfraDomain.py
+++ b/API/EMInfraDomain.py
@@ -246,10 +246,10 @@ class BestekRef(BaseDataclass):
     type: str
     actief: bool
     links: [Link]
-    eDeltaDossiernummer: str | None
-    eDeltaBesteknummer: str | None
-    aannemerNaam: str | None
-    aannemerReferentie: str | None
+    eDeltaDossiernummer: str | None = None
+    eDeltaBesteknummer: str | None = None
+    aannemerNaam: str | None = None
+    aannemerReferentie: str | None = None
     nummer: str | None = None
     lot: str | None = None
 

--- a/UseCases/Bestekkoppelingen/ontkoppel_bestekkoppelingen_leeg_bestek.py
+++ b/UseCases/Bestekkoppelingen/ontkoppel_bestekkoppelingen_leeg_bestek.py
@@ -1,0 +1,51 @@
+import os
+import pandas as pd
+
+from datetime import datetime
+from pathlib import Path
+
+from API.EMInfraClient import EMInfraClient
+from API.Enums import AuthType, Environment
+
+
+if __name__ == '__main__':
+    filepath = Path(r"C:\Users\DriesVerdoodtNordend\Downloads\[RSA] Assets gelinkt aan bestekken zonder aannemer.xlsx")
+    df_assets = pd.read_excel(filepath, sheet_name='Resultaat', header=2,
+                              usecols=["uuid", "assettype", "naampad"])
+
+    environment = Environment.PRD
+    settings_path = Path(os.environ["OneDrive"]) / 'projects/AWV/resources/settings_SyncOTLDataToLegacy.json'
+    eminfra_client = EMInfraClient(env=environment, auth_type=AuthType.JWT, settings_path=settings_path)
+
+    print("\tStart updating bestekkoppelingen")
+    for index, asset in df_assets.iterrows():
+        # Ophalen van alle bestekkoppelingen
+        asset_uuid = asset.uuid
+        print(f'Asset uuid: {asset_uuid}')
+
+        bestekkoppelingen = eminfra_client.get_bestekkoppelingen_by_asset_uuid(asset_uuid=asset_uuid)
+
+        # Hoeveel bestekkoppelingen zijn er aanwezig? Meer dan 1.
+        if len(bestekkoppelingen) <= 1:
+            raise ValueError("0 or 1 bestekkoppeling found")
+
+        # Testen dat exact 1 bestekkoppeling geen waardes heeft voor bepaalde keys
+        matching_elements = [
+            item for item in bestekkoppelingen
+            if (item.bestekRef.aannemerNaam is None
+                and
+                item.bestekRef.aannemerReferentie is None
+                and
+                item.bestekRef.eDeltaBesteknummer is None
+                and
+                item.bestekRef.eDeltaDossiernummer is None
+                )
+        ]
+
+        if len(matching_elements) != 1:
+            raise ValueError("Meerdere bestekkoppelingen zonder waardes")
+
+        # Er zijn minstens 2 bestekkoppelingen, waarvan maximum 1 zonder waardes. Als deze voorwaardes zijn vervuld, kan de bestekkoppeling gedeactiveerd worden.
+        # Deactiveer de bestekkoppeling zonder waarde
+        bestek_ref_uuid = matching_elements[0].bestekRef.uuid
+        eminfra_client.end_bestekkoppeling(asset_uuid=asset_uuid, bestek_ref_uuid=bestek_ref_uuid) # set no end_date. Ends the bestek today.

--- a/utils/date_helpers.py
+++ b/utils/date_helpers.py
@@ -48,8 +48,5 @@ def format_datetime(datetime: datetime) -> str:
     :return: date as string '%Y-%m-%dT00:00:00.000+00:00'
     """
     hour_interval = get_winter_summer_time_interval(date=datetime)
-<<<<<<< HEAD
     return f'{datetime.strftime("%Y-%m-%d")}T00:00:00.000+0{hour_interval}:00'
-=======
-    return f'{datetime.strftime("%Y-%m-%d")}T00:00:00.000+0{hour_interval}:00'
->>>>>>> origin/master
+


### PR DESCRIPTION
## Summary by Sourcery

Implement the disconnection of specification links for empty specifications. This involves modifying the BestekRef dataclass to allow None values for certain attributes and adding a new script to handle the disconnection logic.

Chores:
- Modify the BestekRef dataclass to allow None values for attributes like aannemerNaam, aannemerReferentie, eDeltaBesteknummer, and eDeltaDossiernummer.
- Add a new script to disconnect specification links for empty specifications.