### PR TITLE
88 locatieservices2 client toevoegen

### DIFF
--- a/API/Locatieservices2Client.py
+++ b/API/Locatieservices2Client.py
@@ -1,28 +1,14 @@
-import json
 import logging
-import uuid
 
-from collections.abc import Generator
 from dataclasses import dataclass
-from datetime import datetime, timedelta
 
 from pathlib import Path
-from datetime import datetime
 
-from API.EMInfraDomain import OperatorEnum, TermDTO, ExpressionDTO, SelectionDTO, PagingModeEnum, QueryDTO, BestekRef, \
-    BestekKoppeling, FeedPage, AssettypeDTO, AssettypeDTOList, DTOList, AssetDTO, BetrokkenerelatieDTO, AgentDTO, \
-    PostitDTO, LogicalOpEnum, BestekCategorieEnum, BestekKoppelingStatusEnum, AssetDocumentDTO, LocatieKenmerk, \
-    LogicalOpEnum, ToezichterKenmerk, IdentiteitKenmerk, AssetTypeKenmerkTypeDTO, KenmerkTypeDTO, \
-    AssetTypeKenmerkTypeAddDTO, ResourceRefDTO, Eigenschap, Event, EventType, ObjectType, EventContext, ExpansionsDTO, \
-    RelatieTypeDTO, KenmerkType, EigenschapValueDTO, RelatieTypeDTOList, BeheerobjectDTO, ToezichtgroepTypeEnum, \
-    ToezichtgroepDTO, BaseDataclass, BeheerobjectTypeDTO, BoomstructuurAssetTypeEnum, KenmerkTypeEnum, AssetDTOToestand, \
-    EigenschapValueUpdateDTO, GeometryNiveau, GeometryBron, GeometryNauwkeurigheid, GeometrieKenmerk
+from API.EMInfraDomain import BaseDataclass
 from API.Enums import AuthType, Environment
 from API.Locatieservices2Domain import WegsegmentPuntLocatie
 from API.RequesterFactory import RequesterFactory
-from utils.date_helpers import validate_dates, format_datetime
-from utils.query_dto_helpers import add_expression
-import os
+
 
 
 @dataclass
@@ -53,4 +39,14 @@ class Locatieservices2Client:
             logging.error(response)
             raise ProcessLookupError(response.content.decode("utf-8"))
 
-        return [WegsegmentPuntLocatie.from_dict(item) for item in response.json()['data']]
+        return WegsegmentPuntLocatie.from_dict(response.json())
+
+    def zoek_puntlocatie_via_wegsegment(self, ident8: str, opschrift: float, afstand: float = 0.0) -> WegsegmentPuntLocatie:
+        response = self.requester.get(
+            url=f'rest/puntlocatie/op/weg/{ident8}/via/opschrift?opschrift={opschrift}&afstand={afstand}'
+        )
+        if response.status_code != 200:
+            logging.error(response)
+            raise ProcessLookupError(response.content.decode("utf-8"))
+
+        return WegsegmentPuntLocatie.from_dict(response.json())

--- a/API/Locatieservices2Client.py
+++ b/API/Locatieservices2Client.py
@@ -1,0 +1,56 @@
+import json
+import logging
+import uuid
+
+from collections.abc import Generator
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from pathlib import Path
+from datetime import datetime
+
+from API.EMInfraDomain import OperatorEnum, TermDTO, ExpressionDTO, SelectionDTO, PagingModeEnum, QueryDTO, BestekRef, \
+    BestekKoppeling, FeedPage, AssettypeDTO, AssettypeDTOList, DTOList, AssetDTO, BetrokkenerelatieDTO, AgentDTO, \
+    PostitDTO, LogicalOpEnum, BestekCategorieEnum, BestekKoppelingStatusEnum, AssetDocumentDTO, LocatieKenmerk, \
+    LogicalOpEnum, ToezichterKenmerk, IdentiteitKenmerk, AssetTypeKenmerkTypeDTO, KenmerkTypeDTO, \
+    AssetTypeKenmerkTypeAddDTO, ResourceRefDTO, Eigenschap, Event, EventType, ObjectType, EventContext, ExpansionsDTO, \
+    RelatieTypeDTO, KenmerkType, EigenschapValueDTO, RelatieTypeDTOList, BeheerobjectDTO, ToezichtgroepTypeEnum, \
+    ToezichtgroepDTO, BaseDataclass, BeheerobjectTypeDTO, BoomstructuurAssetTypeEnum, KenmerkTypeEnum, AssetDTOToestand, \
+    EigenschapValueUpdateDTO, GeometryNiveau, GeometryBron, GeometryNauwkeurigheid, GeometrieKenmerk
+from API.Enums import AuthType, Environment
+from API.Locatieservices2Domain import WegsegmentPuntLocatie
+from API.RequesterFactory import RequesterFactory
+from utils.date_helpers import validate_dates, format_datetime
+from utils.query_dto_helpers import add_expression
+import os
+
+
+@dataclass
+class Query(BaseDataclass):
+    size: int
+    filters: dict
+    orderByProperty: str
+    fromCursor: str | None = None
+
+
+class Locatieservices2Client:
+    def __init__(self, auth_type: AuthType, env: Environment, settings_path: Path = None, cookie: str = None):
+        self.requester = RequesterFactory.create_requester(auth_type=auth_type, env=env, settings_path=settings_path,
+                                                           cookie=cookie)
+        self.requester.first_part_url += 'locatieservices2/'
+
+    def zoek_puntlocatie_via_xy(self, x: float, y: float, zoekafstand: int = 50) -> WegsegmentPuntLocatie:
+        """
+        Zoek de dichtstbijgelegen puntlocatie
+        :param x: x coordinate
+        :param y: y coordinate
+        :param zoekafstand: zoekafstand in meter. Default 50.
+        :return:
+        """
+        response = self.requester.get(
+            url=f'rest/puntlocatie/via/xy?/zoekafstand={zoekafstand}&x={x}&y={y}')
+        if response.status_code != 200:
+            logging.error(response)
+            raise ProcessLookupError(response.content.decode("utf-8"))
+
+        return [WegsegmentPuntLocatie.from_dict(item) for item in response.json()['data']]

--- a/API/Locatieservices2Domain.py
+++ b/API/Locatieservices2Domain.py
@@ -1,0 +1,83 @@
+import json
+from dataclasses import dataclass
+from enum import Enum
+from json import dumps
+
+
+class WegsegmenttypeEnum(Enum):
+    WEGSEGMENTPUNTLOCATIE = 'WegsegmentPuntLocatie'
+    # aanvullen met andere types
+
+RESERVED_WORD_LIST = ('from_', '_next')
+
+@dataclass
+class BaseDataclass:
+    def __dict_factory_override__(self):
+        normal_dict = {k: getattr(self, k) for k in self.__dataclass_fields__}
+        d = {}
+        for k, v in normal_dict.items():
+            if k in RESERVED_WORD_LIST:
+                k = k[:-1]
+
+            d[k] = v.value if isinstance(v, Enum) else v
+        return d
+
+    def asdict(self):
+        return asdict(self)
+
+    def json(self):
+        """
+        get the json formatted string
+        """
+        d = self.asdict()
+        return dumps(self.asdict())
+
+    @classmethod
+    def from_dict(cls, dict_: dict):
+        for k in list(dict_.keys()):
+            if k in RESERVED_WORD_LIST:
+                dict_[f'{k}_'] = dict_[k]
+                del dict_[k]
+        return cls(**dict_)
+
+    def _fix_enums(self, list_of_fields: set[tuple[str, type]]):
+        for field_tuple in list_of_fields:
+            attr = getattr(self, field_tuple[0])
+            if attr is not None:
+                setattr(self, field_tuple[0], field_tuple[1](attr))
+
+    def _fix_nested_classes(self, list_of_fields: set[tuple[str, type]]):
+        for field_tuple in list_of_fields:
+            attr = getattr(self, field_tuple[0])
+            if attr is not None and isinstance(attr, dict):
+                setattr(self, field_tuple[0], field_tuple[1].from_dict(attr))
+
+    def _fix_nested_list_classes(self, list_of_fields: set[tuple[str, type]]):
+        for field_tuple in list_of_fields:
+            attr = getattr(self, field_tuple[0])
+            if attr is not None and isinstance(attr, list) and len(attr) > 0 and isinstance(attr[0], dict):
+                setattr(self, field_tuple[0], [field_tuple[1].from_dict(a) for a in attr])
+
+
+    def __str__(self):
+        return json.dumps(self.asdict(), indent=4, sort_keys=True)
+
+@dataclass
+class WegsegmentId(BaseDataclass):
+    gidn: str
+    oidn: str
+    uidn: str
+
+@dataclass
+class JSONGeom(BaseDataclass):
+    type: str
+    coordinates: list[float]
+    bbox: list[float]
+    crs: dict
+
+@dataclass
+class WegsegmentPuntLocatie(BaseDataclass):
+   type: WegsegmenttypeEnum
+   geometry: JSONGeom
+   projectie: JSONGeom
+   wegsegmentId: WegsegmentId

--- a/UseCases/Locatieservices2/Lichtmast.py
+++ b/UseCases/Locatieservices2/Lichtmast.py
@@ -16,8 +16,7 @@ LICHTMAST_REGEX_PATTERN = r'[a-zA-Z]{1}\d{1,3}[NPMXnpmx]{1}\d+\.?\d*\.[P]\d*'
 
 def load_settings():
     """Load API settings from JSON"""
-    settings_path = Path().home() / 'OneDrive - Nordend/projects/AWV/resources/settings_SyncOTLDataToLegacy.json'
-    return settings_path
+    return Path().home() / 'OneDrive - Nordend/projects/AWV/resources/settings_SyncOTLDataToLegacy.json'
 
 def is_full_match(name: str, pattern: str = LICHTMAST_REGEX_PATTERN) -> bool:
     """
@@ -78,7 +77,9 @@ def asset_naam_past_in_boomstructuur(naampad: str) -> bool:
     try:
         i_pos, i_ident8, i_opschrift = parse_lichtmast_naam(naam=installatie_naam)
         a_pos, a_ident8, a_opschrift = parse_lichtmast_naam(naam=asset_naam)
-    except Exception:
+    except Exception as e:
+        logging.exception("Failed to parse lichtmast naam for installatie_naam '%s' or asset_naam '%s'",
+                          installatie_naam, asset_naam)
         return None
 
     logging.debug(f'installatie: {installatie_naam}')
@@ -134,8 +135,8 @@ if __name__ == '__main__':
             else:
                 distance = round(get_euclidean_distance_wkt(wkt1=df_asset.get("geometry"), wkt2=wkt_geom_referentiepunt))
 
-        except:
-            logging.debug('Locatieservices kon de locatie niet ophalen.')
+        except Exception as e:
+            logging.debug(f'Locatieservices kon de locatie niet ophalen. Foutmelding: {e}')
             wkt_geom_referentiepunt = 'werd niet teruggevonden'
             distance = None
 
@@ -147,7 +148,7 @@ if __name__ == '__main__':
     df_assets["afstand"] = afstand
 
     # Append hyperlink eminfra
-    df_assets["eminfra"] = 'https://apps.mow.vlaanderen.be/eminfra/assets/' + df_assets["assetId.identificator"][:36]
+    df_assets["eminfra"] = 'https://apps.mow.vlaanderen.be/eminfra/assets/' + df_assets["assetId.identificator"].str[:36]
 
     # Append hyperlink to openstreetmap
     df_assets[["osm_link"]] = df_assets["geometrie_referentiepunt"].apply(lambda wkt: pd.Series(generate_osm_link(wkt)))

--- a/UseCases/Locatieservices2/test_locatieservices2.py
+++ b/UseCases/Locatieservices2/test_locatieservices2.py
@@ -1,0 +1,24 @@
+import logging
+
+from API.EMInfraClient import EMInfraClient
+from API.EMInfraDomain import AssetDTO
+from API.Enums import AuthType, Environment
+import pandas as pd
+from pathlib import Path
+
+from API.Locatieservices2Client import Locatieservices2Client
+
+
+def load_settings():
+    """Load API settings from JSON"""
+    settings_path = Path().home() / 'OneDrive - Nordend/projects/AWV/resources/settings_SyncOTLDataToLegacy.json'
+    return settings_path
+
+
+if __name__ == '__main__':
+    logging.basicConfig(filename="logs.log", level=logging.DEBUG, format='%(levelname)s:\t%(asctime)s:\t%(message)s', filemode="w")
+    logging.info('Test Locatieservices2 (LS2)')
+    settings_path = load_settings()
+    ls2_client = Locatieservices2Client(env=Environment.TEI, auth_type=AuthType.JWT, settings_path=settings_path)
+
+    print(ls2_client)

--- a/UseCases/Locatieservices2/test_locatieservices2.py
+++ b/UseCases/Locatieservices2/test_locatieservices2.py
@@ -1,9 +1,7 @@
 import logging
+import re
 
-from API.EMInfraClient import EMInfraClient
-from API.EMInfraDomain import AssetDTO
 from API.Enums import AuthType, Environment
-import pandas as pd
 from pathlib import Path
 
 from API.Locatieservices2Client import Locatieservices2Client
@@ -14,6 +12,18 @@ def load_settings():
     settings_path = Path().home() / 'OneDrive - Nordend/projects/AWV/resources/settings_SyncOTLDataToLegacy.json'
     return settings_path
 
+def is_full_match(name: str, pattern: str = '[a-zA-Z]{1}\d{1,3}[NPMXnpmx]{1}\d+\.?\d*\.[P]\d*') -> bool:
+    """
+    Returns True if the entire string matches the given regex pattern.
+
+    :type name: str
+    :param name: The input string to test.
+    :type pattern: str
+    :param pattern: The regular expression pattern.
+    :return: Boolean indicating if full match occurred.
+    """
+    return re.fullmatch(pattern, name) is not None
+
 
 if __name__ == '__main__':
     logging.basicConfig(filename="logs.log", level=logging.DEBUG, format='%(levelname)s:\t%(asctime)s:\t%(message)s', filemode="w")
@@ -21,4 +31,39 @@ if __name__ == '__main__':
     settings_path = load_settings()
     ls2_client = Locatieservices2Client(env=Environment.TEI, auth_type=AuthType.JWT, settings_path=settings_path)
 
-    print(ls2_client)
+    logging.debug('Debug functie zoek_puntlocatie_via_xy()')
+    x = 158190.21
+    y = 164766.15
+    wegsegment_puntlocatie = ls2_client.zoek_puntlocatie_via_xy(x=x, y=y)
+    logging.debug(f'Gevonden Puntlocatie: {wegsegment_puntlocatie}')
+
+    logging.debug('Debug functie zoek_puntlocatie_via_wegsegment()')
+    ident8='N0080001'
+    opschrift='4.6'
+    afstand='1.5'
+    wegsegment_puntlocatie = ls2_client.zoek_puntlocatie_via_wegsegment(ident8=ident8, opschrift=opschrift, afstand=afstand)
+    logging.debug(f'Gevonden Puntlocatie: {wegsegment_puntlocatie}')
+
+    # Import Excel-file as pandas dataframe
+
+    # Todo functie toevoegen om input te parsen naar ident8, richting en opschrift
+    # Start met een regex-validatie
+    # omit .P op het einde
+    # Splits op basis van de karakters ['P', 'N', 'X', 'M'].
+    # Het eerste deel is de ident8 en het tweede deel het opschrift
+
+    # Todo functie toevoegen om een bepaald wegnummer te converteren naar de juiste syntax van ident8
+    lichtmast_naam = 'A18N27.45.P'
+    is_full_match(name=lichtmast_naam)
+    logging.debug('Debug functie name_validation()')
+
+    logging.info('Extraheer het eerste deel van een string')
+    lichtmast_naam_basis = re.match(pattern='[a-zA-Z]{1}\d{1,3}[NPMXnpmx]{1}\d+\.?\d*', string=lichtmast_naam)[0]
+
+    logging.info('Extraheer de aanduiding van de richting (NMPX), alsook de indexpositie in de string')
+    match = re.search(pattern=r"(?<=[0-9])([MNPX])(?=[0-9])", string=lichtmast_naam_basis, flags=re.IGNORECASE)
+    index = match.start()
+    positie_rijweg = match.group()
+
+    ident8_raw = lichtmast_naam_basis[:index]
+    opschrift = lichtmast_naam_basis[index:]

--- a/UseCases/Locatieservices2/test_locatieservices2.py
+++ b/UseCases/Locatieservices2/test_locatieservices2.py
@@ -40,9 +40,9 @@ def parse_lichtmast_naam(naam: str):
     positie_rijweg = match.group()
 
     ident8_raw = lichtmast_naam_basis[:index]
-    opschrift = lichtmast_naam_basis[index:]
+    opschrift = str(round(float(lichtmast_naam_basis[index+1:]), 1)) # afronden tot op 1 decimaal getal
 
-    # to implement: functie om ident8_raw naar een ident8 van exact 8 digits om te zetten?
+
     ident8 = convert_ident8(ident8=ident8_raw, direction=positie_rijweg)
 
     return positie_rijweg, ident8, opschrift
@@ -69,23 +69,60 @@ if __name__ == '__main__':
     # logging.debug(f'Gevonden Puntlocatie: {wegsegment_puntlocatie}')
 
     # Import Excel-file as pandas dataframe
-    filepath_excel = Path().home() / 'Downloads' / 'Lichtmast' / 'DA-2025-43571_export.xlsx'
+    filepath_excel_input = Path().home() / 'Downloads' / 'Lichtmast' / 'DA-2025-43571_export.xlsx'
+    filepath_excel_output = Path().home() / 'Downloads' / 'Lichtmast' / 'DA-2025-XXXXX_import.xlsx'
     usecols = ['typeURI', 'assetId.identificator', 'naam', 'naampad', 'toestand', 'geometry']
-    df_assets = pd.read_excel(filepath_excel, sheet_name='Lichtmast', usecols=usecols)
+    df_assets = pd.read_excel(filepath_excel_input, sheet_name='Lichtmast', usecols=usecols)
 
+    geometrie_refentiepunt = []
+    afstand = []
     for idx, df_asset in df_assets.iterrows():
         logging.debug(f'{idx}: Processing asset: {df_asset.get("assetId.identificator")[:36]}; naam: {df_asset.get("naam")}')
         asset = eminfra_client.get_asset_by_id(assettype_id=df_asset.get('assetId.identificator')[:36])
         logging.debug(f'{idx}: Processing asset: {asset.uuid}; naam: {asset.naam}')
+        if asset.naam is None:
+            geometrie_refentiepunt.append(None)
+            afstand.append(None)
+            continue
 
         if not is_full_match(name=asset.naam, pattern='[a-zA-Z]{1}\d{1,3}[NPMXnpmx]{1}\d+\.?\d*\.[P]\d*'):
             logging.debug(f'{asset.type.label}: {asset.naam} volgt NIET de naamconventie')
+            geometrie_refentiepunt.append(None)
+            afstand.append(None)
             continue
 
-        positie_rijweg, ident8_raw, opschrift = parse_lichtmast_naam(naam=asset.naam)
+        positie_rijweg, ident8, opschrift = parse_lichtmast_naam(naam=asset.naam)
 
-        wegsegment_puntlocatie = ls2_client.zoek_puntlocatie_via_wegsegment(ident8=ident8_raw, opschrift=opschrift)
-        wkt_geom_projected = coordinates_2_wkt(wegsegment_puntlocatie.geometry.coordinates)
-        distance = get_euclidean_distance_wkt(wkt1=df_asset.get("geometry"), wkt2=wkt_geom_projected)
+        logging.debug('Zoek puntlocatie via wegsegment.')
+        logging.debug(f'ident8: {ident8}')
+        logging.debug(f'opschrift: {opschrift}')
 
-        # geometry_referentiepunt
+        try:
+            wegsegment_puntlocatie = ls2_client.zoek_puntlocatie_via_wegsegment(ident8=ident8, opschrift=opschrift)
+            wkt_geom_referentiepunt = coordinates_2_wkt(wegsegment_puntlocatie.geometry.coordinates)
+
+            wkt1 = df_asset.get("geometry")
+            wkt2 = wkt_geom_referentiepunt
+            if pd.isna(wkt1) or pd.isna(wkt2):
+                distance = None
+            else:
+                distance = round(get_euclidean_distance_wkt(wkt1=df_asset.get("geometry"), wkt2=wkt_geom_referentiepunt))
+
+        except:
+            logging.debug('Locatieservices kon de locatie niet ophalen.')
+            wkt_geom_referentiepunt = 'werd niet teruggevonden'
+            distance = None
+
+        geometrie_refentiepunt.append(wkt_geom_referentiepunt)
+        afstand.append(distance)
+
+
+    # Append to dataframe
+    df_assets["geometrie_referentiepunt"] = geometrie_refentiepunt
+    df_assets["afstand"] = afstand
+
+    # Append hyperlink
+    df_assets["eminfra"] = 'https://apps.mow.vlaanderen.be/eminfra/assets/' + df_assets["assetId.identificator"][:36]
+
+    logging.debug(f'Write pandas dataframe to Excel: {filepath_excel_output}')
+    df_assets.to_excel(filepath_excel_output, sheet_name='Lichtmast', freeze_panes=[1,2], index=False)

--- a/UseCases/Locatieservices2/test_locatieservices2.py
+++ b/UseCases/Locatieservices2/test_locatieservices2.py
@@ -1,10 +1,15 @@
 import logging
 import re
 
+import pandas as pd
+
+from API.EMInfraClient import EMInfraClient
 from API.Enums import AuthType, Environment
 from pathlib import Path
 
 from API.Locatieservices2Client import Locatieservices2Client
+from utils.locatieservice_helpers import convert_ident8
+from utils.wkt_geometry_helpers import coordinates_2_wkt, get_euclidean_distance_wkt
 
 
 def load_settings():
@@ -25,40 +30,9 @@ def is_full_match(name: str, pattern: str = '[a-zA-Z]{1}\d{1,3}[NPMXnpmx]{1}\d+\
     return re.fullmatch(pattern, name) is not None
 
 
-if __name__ == '__main__':
-    logging.basicConfig(filename="logs.log", level=logging.DEBUG, format='%(levelname)s:\t%(asctime)s:\t%(message)s', filemode="w")
-    logging.info('Test Locatieservices2 (LS2)')
-    settings_path = load_settings()
-    ls2_client = Locatieservices2Client(env=Environment.TEI, auth_type=AuthType.JWT, settings_path=settings_path)
-
-    logging.debug('Debug functie zoek_puntlocatie_via_xy()')
-    x = 158190.21
-    y = 164766.15
-    wegsegment_puntlocatie = ls2_client.zoek_puntlocatie_via_xy(x=x, y=y)
-    logging.debug(f'Gevonden Puntlocatie: {wegsegment_puntlocatie}')
-
-    logging.debug('Debug functie zoek_puntlocatie_via_wegsegment()')
-    ident8='N0080001'
-    opschrift='4.6'
-    afstand='1.5'
-    wegsegment_puntlocatie = ls2_client.zoek_puntlocatie_via_wegsegment(ident8=ident8, opschrift=opschrift, afstand=afstand)
-    logging.debug(f'Gevonden Puntlocatie: {wegsegment_puntlocatie}')
-
-    # Import Excel-file as pandas dataframe
-
-    # Todo functie toevoegen om input te parsen naar ident8, richting en opschrift
-    # Start met een regex-validatie
-    # omit .P op het einde
-    # Splits op basis van de karakters ['P', 'N', 'X', 'M'].
-    # Het eerste deel is de ident8 en het tweede deel het opschrift
-
-    # Todo functie toevoegen om een bepaald wegnummer te converteren naar de juiste syntax van ident8
-    lichtmast_naam = 'A18N27.45.P'
-    is_full_match(name=lichtmast_naam)
-    logging.debug('Debug functie name_validation()')
-
+def parse_lichtmast_naam(naam: str):
     logging.info('Extraheer het eerste deel van een string')
-    lichtmast_naam_basis = re.match(pattern='[a-zA-Z]{1}\d{1,3}[NPMXnpmx]{1}\d+\.?\d*', string=lichtmast_naam)[0]
+    lichtmast_naam_basis = re.match(pattern='[a-zA-Z]{1}\d{1,3}[NPMXnpmx]{1}\d+\.?\d*', string=naam)[0]
 
     logging.info('Extraheer de aanduiding van de richting (NMPX), alsook de indexpositie in de string')
     match = re.search(pattern=r"(?<=[0-9])([MNPX])(?=[0-9])", string=lichtmast_naam_basis, flags=re.IGNORECASE)
@@ -67,3 +41,51 @@ if __name__ == '__main__':
 
     ident8_raw = lichtmast_naam_basis[:index]
     opschrift = lichtmast_naam_basis[index:]
+
+    # to implement: functie om ident8_raw naar een ident8 van exact 8 digits om te zetten?
+    ident8 = convert_ident8(ident8=ident8_raw, direction=positie_rijweg)
+
+    return positie_rijweg, ident8, opschrift
+
+
+if __name__ == '__main__':
+    logging.basicConfig(filename="logs.log", level=logging.DEBUG, format='%(levelname)s:\t%(asctime)s:\t%(message)s', filemode="w")
+    logging.info('Test Locatieservices2 (LS2)')
+    settings_path = load_settings()
+    ls2_client = Locatieservices2Client(env=Environment.PRD, auth_type=AuthType.JWT, settings_path=settings_path)
+    eminfra_client = EMInfraClient(env=Environment.PRD, auth_type=AuthType.JWT, settings_path=settings_path)
+
+    # logging.debug('Debug functie zoek_puntlocatie_via_xy()')
+    # x = 158190.21
+    # y = 164766.15
+    # wegsegment_puntlocatie = ls2_client.zoek_puntlocatie_via_xy(x=x, y=y)
+    # logging.debug(f'Gevonden Puntlocatie: {wegsegment_puntlocatie}')
+    #
+    # logging.debug('Debug functie zoek_puntlocatie_via_wegsegment()')
+    # ident8='N0080001'
+    # opschrift='4.6'
+    # afstand='1.5'
+    # wegsegment_puntlocatie = ls2_client.zoek_puntlocatie_via_wegsegment(ident8=ident8, opschrift=opschrift, afstand=afstand)
+    # logging.debug(f'Gevonden Puntlocatie: {wegsegment_puntlocatie}')
+
+    # Import Excel-file as pandas dataframe
+    filepath_excel = Path().home() / 'Downloads' / 'Lichtmast' / 'DA-2025-43571_export.xlsx'
+    usecols = ['typeURI', 'assetId.identificator', 'naam', 'naampad', 'toestand', 'geometry']
+    df_assets = pd.read_excel(filepath_excel, sheet_name='Lichtmast', usecols=usecols)
+
+    for idx, df_asset in df_assets.iterrows():
+        logging.debug(f'{idx}: Processing asset: {df_asset.get("assetId.identificator")[:36]}; naam: {df_asset.get("naam")}')
+        asset = eminfra_client.get_asset_by_id(assettype_id=df_asset.get('assetId.identificator')[:36])
+        logging.debug(f'{idx}: Processing asset: {asset.uuid}; naam: {asset.naam}')
+
+        if not is_full_match(name=asset.naam, pattern='[a-zA-Z]{1}\d{1,3}[NPMXnpmx]{1}\d+\.?\d*\.[P]\d*'):
+            logging.debug(f'{asset.type.label}: {asset.naam} volgt NIET de naamconventie')
+            continue
+
+        positie_rijweg, ident8_raw, opschrift = parse_lichtmast_naam(naam=asset.naam)
+
+        wegsegment_puntlocatie = ls2_client.zoek_puntlocatie_via_wegsegment(ident8=ident8_raw, opschrift=opschrift)
+        wkt_geom_projected = coordinates_2_wkt(wegsegment_puntlocatie.geometry.coordinates)
+        distance = get_euclidean_distance_wkt(wkt1=df_asset.get("geometry"), wkt2=wkt_geom_projected)
+
+        # geometry_referentiepunt

--- a/UseCases/main_template.py
+++ b/UseCases/main_template.py
@@ -6,10 +6,6 @@ from API.Enums import AuthType, Environment
 import pandas as pd
 from pathlib import Path
 
-print(""""
-        Beschrijving van de use-case
-      """)
-
 def load_settings():
     """Load API settings from JSON"""
     settings_path = Path().home() / 'OneDrive - Nordend/projects/AWV/resources/settings_SyncOTLDataToLegacy.json'

--- a/utils/locatieservice_helpers.py
+++ b/utils/locatieservice_helpers.py
@@ -16,11 +16,10 @@ def convert_ident8(ident8: str, direction: str = 'P') -> str:
         raise ValueError(f'De wegletter kon niet worden achterhaald uit ident8: {ident8}')
     weg_letter = match_weg_letter[1]
 
-    if not (match_weg_nummer := re.search(string=ident8, pattern=r'\d+')):
-    # if not (match_weg_nummer := re.search(string=ident8, pattern=r'[a-zA-Z][^a-zA-Z]*?(\d+)')):
+    if not (match_weg_nummer := re.search(string=ident8, pattern=r'(\d+)')):
         raise ValueError(f'Het wegnummer kon niet worden achterhaald uit ident8: {ident8}')
-    print(match_weg_nummer[1])
-    weg_nummer = match_weg_nummer[1].rjust(3, '0')
+    weg_nummer = match_weg_nummer[1]
+    weg_nummer = weg_nummer.rjust(3, '0')
 
     if match := re.search(string=ident8, pattern='([a-zA-Z])$', flags=re.IGNORECASE):
         ident8_suffix = match[1].lower()

--- a/utils/locatieservice_helpers.py
+++ b/utils/locatieservice_helpers.py
@@ -1,0 +1,19 @@
+# to do: implement function that converts a short ident8 (e.g. N8) to
+
+def convert_ident8(ident8: str, direction: str = 'P') -> str:
+    """
+    Converts a short notation of an ident8 road to a long notation of an ident8 road.
+    For example N8 > N0080001
+    :param ident8:
+    :param direction P (positive) or N (negative) direction
+    :return: 8 character number
+    """
+    if direction not in ('N', 'P'):
+        raise ValueError('Parameter direction should be ''P'' (positive) or ''N'' (negative).')
+    weg_letter = ident8[:1]
+    weg_nummer = ident8[1:].ljust(4, 0)
+    if direction == 'P':
+        richting = '0001'
+    else:
+        richting = '0002'
+    return f'{weg_letter}{weg_nummer}{richting}'

--- a/utils/locatieservice_helpers.py
+++ b/utils/locatieservice_helpers.py
@@ -9,9 +9,10 @@ def convert_ident8(ident8: str, direction: str = 'P') -> str:
     :return: 8 character number
     """
     if direction not in ('N', 'P'):
-        raise ValueError('Parameter direction should be ''P'' (positive) or ''N'' (negative).')
+        direction = 'P'
+        # raise ValueError('Parameter direction should be ''P'' (positive) or ''N'' (negative).')
     weg_letter = ident8[:1]
-    weg_nummer = ident8[1:].ljust(4, 0)
+    weg_nummer = ident8[1:].rjust(3, '0')
     if direction == 'P':
         richting = '0001'
     else:

--- a/utils/locatieservice_helpers.py
+++ b/utils/locatieservice_helpers.py
@@ -1,20 +1,29 @@
-# to do: implement function that converts a short ident8 (e.g. N8) to
+import re
+
 
 def convert_ident8(ident8: str, direction: str = 'P') -> str:
     """
     Converts a short notation of an ident8 road to a long notation of an ident8 road.
-    For example N8 > N0080001
+    For example: N8 > N0080001
+    If the road number is followed by a  letter [a-z], the direction starts with 901, etc...
+    a -> 901, b -> 902, etc...
+
     :param ident8:
     :param direction P (positive) or N (negative) direction
     :return: 8 character number
     """
     if direction not in ('N', 'P'):
         direction = 'P'
-        # raise ValueError('Parameter direction should be ''P'' (positive) or ''N'' (negative).')
+
     weg_letter = ident8[:1]
     weg_nummer = ident8[1:].rjust(3, '0')
-    if direction == 'P':
-        richting = '0001'
+
+    if match := re.search(
+        string=ident8, pattern='([a-zA-Z])$', flags=re.IGNORECASE
+    ):
+        ident8_suffix = match[1].lower()
+        richting_deel1 = 901 + (ord(ident8_suffix) - ord('a'))  # 'a' → 901, ..., 'z' → 926
     else:
-        richting = '0002'
-    return f'{weg_letter}{weg_nummer}{richting}'
+        richting_deel1 = '000'
+    richting_deel2 = '1' if direction == 'P' else '2'
+    return f'{weg_letter}{weg_nummer}{richting_deel1}{richting_deel2}'

--- a/utils/locatieservice_helpers.py
+++ b/utils/locatieservice_helpers.py
@@ -16,8 +16,10 @@ def convert_ident8(ident8: str, direction: str = 'P') -> str:
         raise ValueError(f'De wegletter kon niet worden achterhaald uit ident8: {ident8}')
     weg_letter = match_weg_letter[1]
 
-    if not (match_weg_nummer := re.search(string=ident8, pattern=r'[a-zA-Z][^a-zA-Z]*?(\d+)')):
-        raise ValueError(f'De wegnummer kon niet worden achterhaald uit ident8: {ident8}')
+    if not (match_weg_nummer := re.search(string=ident8, pattern=r'\d+')):
+    # if not (match_weg_nummer := re.search(string=ident8, pattern=r'[a-zA-Z][^a-zA-Z]*?(\d+)')):
+        raise ValueError(f'Het wegnummer kon niet worden achterhaald uit ident8: {ident8}')
+    print(match_weg_nummer[1])
     weg_nummer = match_weg_nummer[1].rjust(3, '0')
 
     if match := re.search(string=ident8, pattern='([a-zA-Z])$', flags=re.IGNORECASE):

--- a/utils/locatieservice_helpers.py
+++ b/utils/locatieservice_helpers.py
@@ -12,18 +12,19 @@ def convert_ident8(ident8: str, direction: str = 'P') -> str:
     :param direction P (positive) or N (negative) direction
     :return: 8 character number
     """
-    if direction not in ('N', 'P'):
-        direction = 'P'
+    if not (match_weg_letter := re.search(string=ident8, pattern=r'^([a-zA-Z])')):
+        raise ValueError(f'De wegletter kon niet worden achterhaald uit ident8: {ident8}')
+    weg_letter = match_weg_letter[1]
 
-    weg_letter = ident8[:1]
-    weg_nummer = ident8[1:].rjust(3, '0')
+    if not (match_weg_nummer := re.search(string=ident8, pattern=r'[a-zA-Z][^a-zA-Z]*?(\d+)')):
+        raise ValueError(f'De wegnummer kon niet worden achterhaald uit ident8: {ident8}')
+    weg_nummer = match_weg_nummer[1].rjust(3, '0')
 
-    if match := re.search(
-        string=ident8, pattern='([a-zA-Z])$', flags=re.IGNORECASE
-    ):
+    if match := re.search(string=ident8, pattern='([a-zA-Z])$', flags=re.IGNORECASE):
         ident8_suffix = match[1].lower()
         richting_deel1 = 901 + (ord(ident8_suffix) - ord('a'))  # 'a' → 901, ..., 'z' → 926
     else:
         richting_deel1 = '000'
-    richting_deel2 = '1' if direction == 'P' else '2'
+    richting_deel2 = '2' if direction == 'N' else '1'
+
     return f'{weg_letter}{weg_nummer}{richting_deel1}{richting_deel2}'

--- a/utils/wkt_geometry_helpers.py
+++ b/utils/wkt_geometry_helpers.py
@@ -3,7 +3,9 @@ import math
 import pandas as pd
 
 from API.EMInfraDomain import LocatieKenmerk
-
+import geopandas as gpd
+from shapely.wkt import loads
+from shapely.errors import ShapelyError
 
 def format_locatie_kenmerk_lgc_2_wkt(locatie: LocatieKenmerk) -> str:
     """
@@ -83,3 +85,23 @@ def get_euclidean_distance_wkt(wkt1: str, wkt2: str) -> float:
     coords1 = parse_coordinates(wkt1)
     coords2 = parse_coordinates(wkt2)
     return get_euclidean_distance_coordinates(x1=coords1[0], y1=coords1[1], x2=coords2[0], y2=coords2[1])
+
+def generate_osm_link(wkt_str, crs_input: str = 'EPSG:31370', crs_output: str = 'EPSG:4326', osm_zoom: int = 18) -> str:
+    """
+    Parse een WKT-string naar coordinaten en nadien naar een OSM-link.
+
+    :param wkt_str: WKT punt-geometrie
+    :param crs_input:
+    :param crs_output:
+    :param osm_zoom:
+    :return: OSM-link
+    """
+    try:
+        geom = loads(wkt_str)
+        gdf = gpd.GeoDataFrame(geometry=[geom], crs=crs_input)
+        gdf = gdf.to_crs(crs_output)
+        transformed = gdf.geometry.iloc[0]
+        x, y = transformed.x, transformed.y
+        return f'https://www.openstreetmap.org/#map={osm_zoom}/{y}/{x}'
+    except (TypeError, ShapelyError, AttributeError):
+        return None  # or (None, None, None)

--- a/utils/wkt_geometry_helpers.py
+++ b/utils/wkt_geometry_helpers.py
@@ -1,3 +1,5 @@
+import math
+
 import pandas as pd
 
 from API.EMInfraDomain import LocatieKenmerk
@@ -34,6 +36,15 @@ def parse_coordinates(wkt_geom: str) -> []:
 
     return [int(float(c)) for c in coordinates]
 
+def coordinates_2_wkt(coords: list[float]) -> str:
+    """
+    Transform a list of 2 (or 3) coordinates into a WKT Point Z
+    :param coords:
+    :return:
+    """
+    if len(coords) == 2:
+        coords.append(0.0)
+    return f'POINT Z({coords[0]} {coords[1]} {coords[2]})'
 
 def geometries_are_identical(wkt_geom1, wkt_geom2) -> bool:
     """
@@ -46,3 +57,27 @@ def geometries_are_identical(wkt_geom1, wkt_geom2) -> bool:
     coordinates_1 = parse_coordinates(wkt_geom1)
     coordinates_2 = parse_coordinates(wkt_geom2)
     return coordinates_1 == coordinates_2
+
+def get_euclidean_distance_coordinates(x1: float, y1: float, x2: float, y2: float) -> float:
+    """
+    Returns the Euclidean distance between 2 points
+
+    :param x1:
+    :param y1:
+    :param x2:
+    :param y2:
+    :return:
+    """
+    return math.sqrt((x2-x1)**2 + (y2-y1)**2)
+
+def get_euclidean_distance_wkt(wkt1: str, wkt2: str) -> float:
+    """
+    Returns the Euclidean distance between 2 wkt Point geometries
+
+    :param wkt1:
+    :param wkt2:
+    :return:
+    """
+    coords1 = parse_coordinates(wkt1)
+    coords2 = parse_coordinates(wkt2)
+    return get_euclidean_distance_coordinates(x1=coords1[0], y1=coords1[1], x2=coords2[0], y2=coords2[1])

--- a/utils/wkt_geometry_helpers.py
+++ b/utils/wkt_geometry_helpers.py
@@ -78,6 +78,8 @@ def get_euclidean_distance_wkt(wkt1: str, wkt2: str) -> float:
     :param wkt2:
     :return:
     """
+    if pd.isna(wkt1) or pd.isna(wkt2):
+        return None
     coords1 = parse_coordinates(wkt1)
     coords2 = parse_coordinates(wkt2)
     return get_euclidean_distance_coordinates(x1=coords1[0], y1=coords1[1], x2=coords2[0], y2=coords2[1])

--- a/utils/wkt_geometry_helpers.py
+++ b/utils/wkt_geometry_helpers.py
@@ -1,3 +1,4 @@
+import logging
 import math
 
 import pandas as pd
@@ -44,9 +45,10 @@ def coordinates_2_wkt(coords: list[float]) -> str:
     :param coords:
     :return:
     """
-    if len(coords) == 2:
-        coords.append(0.0)
-    return f'POINT Z({coords[0]} {coords[1]} {coords[2]})'
+    output_coords = coords
+    if len(output_coords) == 2:
+        output_coords.append(0.0)
+    return f'POINT Z({output_coords[0]} {output_coords[1]} {output_coords[2]})'
 
 def geometries_are_identical(wkt_geom1, wkt_geom2) -> bool:
     """
@@ -103,5 +105,12 @@ def generate_osm_link(wkt_str, crs_input: str = 'EPSG:31370', crs_output: str = 
         transformed = gdf.geometry.iloc[0]
         x, y = transformed.x, transformed.y
         return f'https://www.openstreetmap.org/#map={osm_zoom}/{y}/{x}'
-    except (TypeError, ShapelyError, AttributeError):
-        return None  # or (None, None, None)
+    except TypeError as e:
+        logging.debug(f'TypeError {e} occured')
+        return None
+    except ShapelyError as e:
+        logging.debug(f'ShapelyEror {e} occured')
+        return None
+    except AttributeError as e:
+        logging.debug(f'AttributeError {e} occured')
+        return None


### PR DESCRIPTION
close #88

## Summary by Sourcery

Add the Locatieservices2 client with associated domain models and integrate it into a new Lichtmast use-case script that fetches point locations from the API, computes distances, and enriches asset data with OSM and EMInfra links

New Features:
- Implement Locatieservices2Client with methods to retrieve point locations via XY coordinates or road segment ident8 and opschrift
- Define domain dataclasses for Locatieservices2 API responses with custom JSON serialization logic
- Add a Lichtmast use-case script to load assets, query reference locations, calculate distances, and export an enriched Excel report

Enhancements:
- Extend WKT geometry helpers with functions to create WKT points, compute Euclidean distances, and build OpenStreetMap links
- Introduce util to convert short ident8 road identifiers into full 8-character codes

Chores:
- Remove unused print statement from main_template