### PR TITLE
Update heeftbetrokkene relaties voor specifieke agents

### DIFF
--- a/UseCases/betrokkenerelaties/inactieve_agent/agent_mappings.json
+++ b/UseCases/betrokkenerelaties/inactieve_agent/agent_mappings.json
@@ -1,0 +1,32 @@
+{
+    "AFDELING WEGEN OOST-VLAANDEREN": {
+        "old_uuid": "d0e7813d-016c-4b94-b85d-dcead5c0ff1e",
+        "new_value": "V&W Oost-Vlaanderen",
+        "new_uuid": "206ba12e-dcc6-4ed1-887c-978e98aaad41"
+    },
+    "District Antwerpen - inactief": {
+        "old_uuid": "c2333368-8def-4eeb-b826-9394f5c3d5b7",
+        "new_value": "V&W Antwerpen",
+        "new_uuid": "5efe6764-007f-4099-83d9-29d0b2759211"
+    },
+    "District Geel - inactief": {
+        "old_uuid": "1c0c6380-141b-42ca-bed0-9103815b37cc",
+        "new_value": "District Geel 114",
+        "new_uuid": "445786bd-30a9-48d3-8401-c2d88b3db36a"
+    },
+    "District Puurs - inactief": {
+        "old_uuid": "c699d9ef-0782-445b-8798-365b5aee836b",
+        "new_value": "District Puurs 112",
+        "new_uuid": "4da75061-c08c-49f4-9808-fd7dc32038c8"
+    },
+    "District Vilvoorde-autosnelwegen - inactief": {
+        "old_uuid": "351bdd6f-719c-41e1-af33-e19d2009c7bc",
+        "new_value": "District Vilvoorde-gewestwegen 212",
+        "new_uuid": "54e3e789-a590-4f7a-bb31-daf4f48f822a"
+    },
+    "District Vosselaar - inactief": {
+        "old_uuid": "8d07ed95-5978-490a-b28a-03cb77c39841",
+        "new_value": "District Vosselaar 125",
+        "new_uuid": "c04fa312-55f9-4698-a463-0946d00daebf"
+    }
+}

--- a/UseCases/betrokkenerelaties/inactieve_agent/update_agent.py
+++ b/UseCases/betrokkenerelaties/inactieve_agent/update_agent.py
@@ -1,0 +1,59 @@
+import logging
+import json
+
+from API.EMInfraClient import EMInfraClient
+from API.EMInfraDomain import AssetDTO, QueryDTO, PagingModeEnum, SelectionDTO, ExpressionDTO, TermDTO, OperatorEnum
+from API.Enums import AuthType, Environment
+import pandas as pd
+from pathlib import Path
+
+
+def load_settings():
+    """Load API settings from JSON"""
+    return Path().home() / 'OneDrive - Nordend/projects/AWV/resources/settings_SyncOTLDataToLegacy.json'
+
+def build_query_search_betrokkenerelaties(asset: AssetDTO):
+    return QueryDTO(size=5, from_=0, pagingMode=PagingModeEnum.OFFSET,
+                                 selection=SelectionDTO(expressions=[
+                                     ExpressionDTO(terms=[
+                                         TermDTO(property='bronAsset', operator=OperatorEnum.EQ,
+                                                 value=f'{asset.uuid}')])]))
+
+def map_agent(name):
+    with open("agent_mappings.json", "r", encoding="utf-8") as f:
+        mappings = json.load(f)
+    return mappings[name].get("new_value")
+
+
+if __name__ == '__main__':
+    logging.basicConfig(filename="logs.log", level=logging.DEBUG, format='%(levelname)s:\t%(asctime)s:\t%(message)s', filemode="w")
+    logging.info('Update (vervang) heeftbetrokkenerelatie van bepaalde agents met de waarde van een mapping dictionary')
+    settings_path = load_settings()
+    eminfra_client = EMInfraClient(env=Environment.PRD, auth_type=AuthType.JWT, settings_path=settings_path)
+
+    filepath = '[RSA] Asset (OTL) heeft een inactieve toezichter.xlsx'
+    df_assets = pd.read_excel(filepath, sheet_name='Resultaat', header=2, usecols=["uuid", "naam_agent", "rol"])
+
+    for idx, asset_row in df_assets.iterrows():
+        asset = eminfra_client.get_asset_by_id(assettype_id=asset_row.get("uuid"))
+
+        agent_name_current = asset_row.get("naam_agent")
+        agent_current = next(eminfra_client.search_agent(naam=agent_name_current, actief=False), None)
+        agent_name_new = map_agent(name=agent_name_current)
+        agent_new = next(eminfra_client.search_agent(naam=agent_name_new, actief=True), None)
+        
+        logging.debug(f'Processing asset: {asset.uuid}:')
+        logging.debug(f"Update agent: '{agent_current.naam}' to '{agent_new.naam}'.")
+
+        logging.info('Zoek een specifieke betrokkenerelatie, deactiveer deze en voeg een nieuwe toe met dezelfde rol.')
+        query_betrokkenerelaties = build_query_search_betrokkenerelaties(asset=asset)
+        betrokkenerelaties = list(eminfra_client.search_betrokkenerelaties(query_dto=query_betrokkenerelaties))
+
+        for betrokkenerelatie in betrokkenerelaties:
+            if betrokkenerelatie.doel.get("naam") == agent_current.naam:
+                logging.info('Deactiveer betrokkenerelaties')
+                eminfra_client.remove_betrokkenerelatie(betrokkenerelatie_uuid=betrokkenerelatie.uuid)
+
+                rol = betrokkenerelatie.rol
+                logging.info('Add new betrokkenerelatie')
+                eminfra_client.add_betrokkenerelatie(asset=asset, agent_uuid=agent_new.uuid, rol=betrokkenerelatie.rol)

--- a/UseCases/betrokkenerelaties/inactieve_agent/update_agent.py
+++ b/UseCases/betrokkenerelaties/inactieve_agent/update_agent.py
@@ -51,9 +51,15 @@ if __name__ == '__main__':
 
         for betrokkenerelatie in betrokkenerelaties:
             if betrokkenerelatie.doel.get("naam") == agent_current.naam:
-                logging.info('Deactiveer betrokkenerelaties')
-                eminfra_client.remove_betrokkenerelatie(betrokkenerelatie_uuid=betrokkenerelatie.uuid)
+                try:
+                    logging.info('Deactiveer betrokkenerelaties')
+                    eminfra_client.remove_betrokkenerelatie(betrokkenerelatie_uuid=betrokkenerelatie.uuid)
+                except Exception as e:
+                    logging.critical(f'Error occured: "{e}"')
 
-                rol = betrokkenerelatie.rol
-                logging.info('Add new betrokkenerelatie')
-                eminfra_client.add_betrokkenerelatie(asset=asset, agent_uuid=agent_new.uuid, rol=betrokkenerelatie.rol)
+                try:
+                    rol = betrokkenerelatie.rol
+                    logging.info(f'Add new betrokkenerelatie with role: "{rol}"')
+                    eminfra_client.add_betrokkenerelatie(asset=asset, agent_uuid=agent_new.uuid, rol=betrokkenerelatie.rol)
+                except Exception as e:
+                    logging.critical(f'Error occured: "{e}"')


### PR DESCRIPTION
close #99

## Summary by Sourcery

Implement a script to migrate "heeftbetrokkenerelatie" entries for inactive agents by reading an Excel report, mapping old agent names to new ones via a JSON mapping, and replacing the relationships through the EMInfra API.

New Features:
- Add update_agent.py to load settings, read asset data from Excel, deactivate old agent relationships, and create new ones based on a mapping
- Add agent_mappings.json to store old-to-new agent name mappings used by the update script