### PR TITLE
Betrokkenerelatie wissen en toevoegen

### DIFF
--- a/UseCases/Toezichter/update_inactieve_toezichters_LGC2OTL.py
+++ b/UseCases/Toezichter/update_inactieve_toezichters_LGC2OTL.py
@@ -9,6 +9,10 @@ from otlmow_model.OtlmowModel.Classes.ImplementatieElement.RelatieObject import 
 from otlmow_model.OtlmowModel.Helpers.RelationCreator import create_betrokkenerelation
 from otlmow_converter.OtlmowConverter import OtlmowConverter
 
+BASE_DIR = Path.home() / "OneDrive - Nordend/projects/AWV/OTL_Aanpassingen/Toezichter_update"
+INPUT_FILE = BASE_DIR / "input" / "toezichter_mapping_link_OTL-Legacy_20250909.xlsx"
+OUTPUT_DIR = BASE_DIR / "output"
+
 DICT_TOEZICHTSGROEPEN = {
     "V&W-WA": "V&W Antwerpen",
     "V&W-WVB": "V&W Vlaams-Brabant",
@@ -33,8 +37,8 @@ def load_settings():
     """Load API settings from JSON"""
     return Path().home() / 'OneDrive - Nordend/projects/AWV/resources/settings_SyncOTLDataToLegacy.json'
 
-def build_betrokkenerelatie(source: AssetDTO, agent_naam :str, rol: str) -> RelatieObject | None:
-    generator_agents = eminfra_client.get_objects_from_oslo_search_endpoint(
+def build_betrokkenerelatie(client: EMInfraClient, source: AssetDTO, agent_naam :str, rol: str) -> RelatieObject | None:
+    generator_agents = client.get_objects_from_oslo_search_endpoint(
         url_part='agents'
         , filter_dict={"naam": agent_naam})
     agents = list(generator_agents)
@@ -50,8 +54,8 @@ def build_betrokkenerelatie(source: AssetDTO, agent_naam :str, rol: str) -> Rela
                                      , target_uuid=agent_uuid
                                      , target_typeURI=agent_uri)
 
-def get_bestaande_betrokkenerelaties(asset: AssetDTO, rol: str, isActief: bool) -> Generator[RelatieObject]:
-    generator = eminfra_client.get_objects_from_oslo_search_endpoint(
+def get_bestaande_betrokkenerelaties(client: EMInfraClient, asset: AssetDTO, rol: str, isActief: bool) -> Generator[RelatieObject]:
+    generator = client.get_objects_from_oslo_search_endpoint(
         url_part='betrokkenerelaties'
         , filter_dict={"bronAsset": asset.uuid, 'rol': rol})
 
@@ -77,76 +81,46 @@ def map_toezichtsgroep(toezichtsgroep: str) -> str:
     return DICT_TOEZICHTSGROEPEN[toezichtsgroep]
 
 
-if __name__ == '__main__':
-    logging.basicConfig(filename="logs.log", level=logging.DEBUG, format='%(levelname)s:\t%(asctime)s:\t%(message)s', filemode="w")
-    logging.info('''
-        OTL Toezichters en toezichtsgroepen aanpassen.
-        Op basis van de actuele LGC toezichter en LGC toezichtsgroep, de OTL Agent rol: toezichter en OTL Agent rol: toezichtsgroep updaten.
-        We beschouwen de Legacy informatie als correct en passen de OTL-informatie daaraan aan.
-        Input: Assets die en inactieve toezichter hebben: Martin Van Leuven of Maurits Van Overloop.
-        Output: DAVIE-conforme aanlever bestanden om de huidige Agents (toezichter en toezichtsgroep) te deactiveren en een nieuwe te instantiëren. 
-        ''')
-
-    settings_path = load_settings()
-    eminfra_client = EMInfraClient(env=Environment.PRD, auth_type=AuthType.JWT, settings_path=settings_path)
-
-    df_assets = pd.read_excel(Path().home() / "OneDrive - Nordend/projects/AWV/OTL_Aanpassingen/Toezichter_update" / "input" /
+def load_input(INPUT_FILE) -> pd.DataFrame:
+    df = pd.read_excel(Path().home() / "OneDrive - Nordend/projects/AWV/OTL_Aanpassingen/Toezichter_update" / "input" /
                                         "toezichter_mapping_link_OTL-Legacy_20250909.xlsx"
                               , sheet_name='Toezichters'
                               , header=0
                               , usecols=["uri_otl", "uuid_otl", "naam_otl", "agent_uuid", "agent_naam", "gemeente", "provincie", "hoortBij-relatie", "uri_lgc", "uuid_lgc", "naam_lgc", "toezichter_uuid", "toezichter_naam", "toezichtgroep_uuid", "toezichtgroep_naam", "otl_lgc_link"])
+    return df[df["otl_lgc_link"] == 1]
 
-    logging.info('Verwijder de records waarbij kolom "otl_lgc_link" niet gelijk is aan 1.')
-    df_assets = df_assets[df_assets["otl_lgc_link"] == 1]
 
-    existing_assets = []
-    created_assets = []
-    for index, asset in df_assets.iterrows():
-        logging.info(f'Processing asset {index}: {asset["uuid_otl"]}')
-        #################################################################################
-        ####  Ophalen van de bestaande asset
-        #################################################################################
-        otl_asset = next(eminfra_client.search_asset_by_uuid(asset_uuid=asset["uuid_otl"]))
+def process_assets(client: EMInfraClient, df: pd.DataFrame):
+    existing, created = [], []
+    for idx, row in df.iterrows():
+        asset = next(client.search_asset_by_uuid(asset_uuid=row["uuid_otl"]))
+        for role, name_col, mapper in [
+            ("toezichter", "toezichter_naam", lambda n: n),
+            ("toezichtsgroep", "toezichtgroep_naam", map_toezichtsgroep),
+        ]:
+            # deactivate
+            existing += list(get_bestaande_betrokkenerelaties(client, asset, role, False))
+            # create
+            name = row[name_col]
+            if not name: continue
+            rel = build_betrokkenerelatie(client, asset, mapper(name), role)
+            if rel:
+                rel.assetId.identificator = f"HeeftBetrokkene_{idx}_{role}"
+                created.append(rel)
+    return existing, created
 
-        #################################################################################
-        ####  Wis de bestaande betrokkenerelatie. Set isActief = False
-        #################################################################################
-        logging.info('\tListing existing relations toezichter and toezichtsgroep')
-        bestaande_relatie_toezichter = list(get_bestaande_betrokkenerelaties(asset=otl_asset, rol='toezichter', isActief=False))
-        if bestaande_relatie_toezichter:
-            existing_assets.extend(bestaande_relatie_toezichter)
-        bestaande_relatie_toezichtsgroep = list(get_bestaande_betrokkenerelaties(asset=otl_asset, rol='toezichtsgroep', isActief=False))
-        if bestaande_relatie_toezichtsgroep:
-            existing_assets.extend(bestaande_relatie_toezichtsgroep)
 
-        #################################################################################
-        ####  Maak nieuwe BetrokkeneRelaties
-        #################################################################################
-        logging.info('\tCreating new relations toezichter and toezichtsgroep')
-        # search toezichter and extract the uuid of the toezichter. This ensures that the toezichter exists.
-        toezichter_naam = asset['toezichter_naam']
-        toezichtgroep_naam = asset['toezichtgroep_naam']
+def write_output(existing, created, out_dir: Path):
+    out_dir.mkdir(parents=True, exist_ok=True)
+    OtlmowConverter.from_objects_to_file(out_dir / "assets_delete.xlsx", existing)
+    OtlmowConverter.from_objects_to_file(out_dir / "assets_update.xlsx", created)
 
-        if toezichter_naam:
-            logging.info(f'\t\tToezichter: {toezichter_naam}')
-            nieuwe_relatie_toezichter = build_betrokkenerelatie(source=otl_asset, agent_naam=toezichter_naam, rol='toezichter')
-            if nieuwe_relatie_toezichter is None:
-                continue
-            nieuwe_relatie_toezichter.assetId.identificator = f'HeeftBetrokkene_{index}_toezichter'
-            created_assets.extend([nieuwe_relatie_toezichter])
 
-        if toezichtgroep_naam:
-            logging.info(f'\t\tToezichtsgroep: {toezichtgroep_naam}')
-            nieuwe_relatie_toezichtsgroep = build_betrokkenerelatie(source=otl_asset, agent_naam=map_toezichtsgroep(toezichtgroep_naam),
-                                                                    rol='toezichtsgroep')
-            if nieuwe_relatie_toezichtsgroep is None:
-                continue
-            nieuwe_relatie_toezichtsgroep.assetId.identificator = f'HeeftBetrokkene_{index}_toezichtsgroep'
-            created_assets.extend([nieuwe_relatie_toezichtsgroep])
+def main():
+    client = EMInfraClient(env=Environment.PRD, auth_type=AuthType.JWT, settings_path=load_settings())
+    df = load_input(INPUT_FILE)
+    existing, created = process_assets(client, df)
+    write_output(existing, created, OUTPUT_DIR)
 
-    OtlmowConverter.from_objects_to_file(file_path=Path(Path().home() / "OneDrive - Nordend/projects/AWV"
-                                                        "/OTL_Aanpassingen/Toezichter_update" / 'output' / f'assets_delete_toezichter_toezichtsgroep.xlsx'),
-                                         sequence_of_objects=existing_assets)
-    OtlmowConverter.from_objects_to_file(file_path=Path(Path().home() / "OneDrive - Nordend/projects/AWV"
-                                                        "/OTL_Aanpassingen/Toezichter_update" / 'output' / f'assets_update_toezichter_toezichtsgroep.xlsx'),
-                                         sequence_of_objects=created_assets)
+
+main()


### PR DESCRIPTION
Initial file to delete and add Betrokkenerelaties (toezichter; toezichtsgroep) to OTL-assets.

close #110

## Summary by Sourcery

Introduce a standalone use-case script that reads legacy supervisor mappings from an Excel file, deactivates current Betrokkenerelaties on OTL assets, creates updated relations using the EMInfraClient and OtlmowConverter, and outputs Excel files for asset deactivation and creation.

New Features:
- Add a script to synchronize Betrokkenerelaties for supervisors and supervision groups from legacy LGC data to OTL assets
- Automatically deactivate existing 'toezichter' and 'toezichtsgroep' relations and instantiate new ones based on Excel input
- Include mapping of legacy supervision group names to OTL equivalents and export DAVIE-compliant spreadsheets for deletion and update of assets