### PR TITLE
175 verlengen bestekkoppeling mdm19h01

### DIFF
--- a/UseCases/Bestekkoppeling/MDM_19H01/Verlengen_bestekkoppeling_MDM_19H01.py
+++ b/UseCases/Bestekkoppeling/MDM_19H01/Verlengen_bestekkoppeling_MDM_19H01.py
@@ -79,7 +79,9 @@ def verleng_bestekkoppelingen(client: EMInfraClient,
 
 if __name__ == '__main__':
     configure_logger()
-    logging.info('Verlengen van bestekkoppeling "MDM/19H01" naar 10/12/2026.')
+    logging.info(
+        f'Verlengen van bestekkoppeling "{EDELTA_BESTEKNUMMER}" naar {format_datetime(EINDDATUM)}.'
+    )
     eminfra_client = EMInfraClient(env=Environment.PRD, auth_type=AuthType.JWT, settings_path=load_settings())
 
     logging.info("Query assets...")


### PR DESCRIPTION
close #175

## Summary by Sourcery

Add a script to extend EMInfra bestekkoppelingen for bestek MDM/19H01 to a new end date and export a summary of updated assets to Excel.

New Features:
- Introduce a use case script that updates inactive werkbestek koppelingen for assets linked to bestek MDM/19H01, extending their end date to 10-12-2026.
- Generate an Excel report listing all assets whose bestekkoppeling end date was extended, including metadata and EMInfra links.